### PR TITLE
Handle optional watermarking in VC and add tests

### DIFF
--- a/chatterbox/src/chatterbox/vc.py
+++ b/chatterbox/src/chatterbox/vc.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import librosa
 import torch
-#import perth
 from huggingface_hub import hf_hub_download
 from safetensors.torch import load_file
 
@@ -26,7 +25,8 @@ class ChatterboxVC:
         self.sr = S3GEN_SR
         self.s3gen = s3gen
         self.device = device
-        #self.watermarker = perth.PerthImplicitWatermarker()
+        # Watermarking is optional and disabled by default
+        self.watermarker = None
         if ref_dict is None:
             self.ref_dict = None
         else:
@@ -103,8 +103,10 @@ class ChatterboxVC:
                 ref_dict=self.ref_dict,
             )
             wav = wav.squeeze(0).detach().cpu().numpy()
-            if apply_watermark:
-                watermarked_wav = self.watermarker.apply_watermark(wav, sample_rate=self.sr)
+            if apply_watermark and self.watermarker is not None:
+                watermarked_wav = self.watermarker.apply_watermark(
+                    wav, sample_rate=self.sr
+                )
             else:
                 watermarked_wav = wav
         return torch.from_numpy(watermarked_wav).unsqueeze(0)

--- a/tests/test_vc_watermarking.py
+++ b/tests/test_vc_watermarking.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+# Ensure chatterbox package is on the path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "chatterbox" / "src"))
+
+from chatterbox.vc import ChatterboxVC
+
+
+class DummyS3Gen:
+    def tokenizer(self, audio):
+        return torch.zeros((1, 1)), None
+
+    def inference(self, speech_tokens, ref_dict):
+        return torch.tensor([[0.1, 0.2, 0.3]]), None
+
+
+def fake_load(path, sr):
+    return np.zeros(sr), sr
+
+
+class DummyWatermarker:
+    def apply_watermark(self, wav, sample_rate):
+        return wav + 1
+
+
+def create_vc(monkeypatch, watermarker=None):
+    monkeypatch.setattr("chatterbox.vc.librosa.load", fake_load)
+    s3gen = DummyS3Gen()
+    vc = ChatterboxVC(s3gen=s3gen, device="cpu", ref_dict={})
+    vc.watermarker = watermarker
+    return vc
+
+
+def test_generate_applies_watermark_when_available(monkeypatch):
+    vc = create_vc(monkeypatch, watermarker=DummyWatermarker())
+    out = vc.generate("dummy.wav", apply_watermark=True)
+    expected = torch.tensor([1.1, 1.2, 1.3]).unsqueeze(0)
+    assert torch.allclose(out, expected)
+
+
+def test_generate_skips_watermark_when_unavailable(monkeypatch):
+    vc = create_vc(monkeypatch, watermarker=None)
+    out = vc.generate("dummy.wav", apply_watermark=True)
+    expected = torch.tensor([0.1, 0.2, 0.3]).unsqueeze(0)
+    assert torch.allclose(out, expected)
+
+
+def test_generate_skips_watermark_when_flag_false(monkeypatch):
+    vc = create_vc(monkeypatch, watermarker=DummyWatermarker())
+    out = vc.generate("dummy.wav", apply_watermark=False)
+    expected = torch.tensor([0.1, 0.2, 0.3]).unsqueeze(0)
+    assert torch.allclose(out, expected)


### PR DESCRIPTION
## Summary
- Disable watermarking by default and guard calls in `ChatterboxVC`
- Add unit tests for watermarking enabled and disabled scenarios

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1dd62157483328268712a4ff86589