### PR TITLE
Add trim_silence helper with fade handling and tests

### DIFF
--- a/chatterbox/src/chatterbox/__init__.py
+++ b/chatterbox/src/chatterbox/__init__.py
@@ -1,2 +1,5 @@
 from .tts import ChatterboxTTS
 from .vc import ChatterboxVC
+from .utils import trim_silence
+
+__all__ = ["ChatterboxTTS", "ChatterboxVC", "trim_silence"]

--- a/chatterbox/src/chatterbox/utils.py
+++ b/chatterbox/src/chatterbox/utils.py
@@ -1,15 +1,48 @@
-# import numpy as np
-#
-#
-# def trim_silence(wav, speech_timestamps, sr):
-#     """TODO: fading"""
-#     if len(speech_timestamps) == 0:
-#         return wav  # WARNING: no speech detected, returning original wav
-#     segs = []
-#     for segment in speech_timestamps:
-#         start_s, end_s = segment['start'], segment['end']
-#         start = int(start_s * sr)
-#         end = int(end_s * sr)
-#         seg = wav[start: end]
-#         segs.append(seg)
-#     return np.concatenate(segs)
+import numpy as np
+from typing import Iterable, Dict, List
+
+
+def trim_silence(wav: np.ndarray, speech_timestamps: Iterable[Dict[str, float]], sr: int, fade_duration: float = 0.01) -> np.ndarray:
+    """Trim non-speech portions from an audio waveform.
+
+    Parameters
+    ----------
+    wav : np.ndarray
+        1-D array of audio samples.
+    speech_timestamps : Iterable[dict]
+        Iterable of mappings with ``start`` and ``end`` times (in seconds)
+        describing regions of speech in ``wav``.
+    sr : int
+        Sample rate of ``wav``.
+    fade_duration : float, optional
+        Length of the linear fade (in seconds) applied to the start and end
+        of each speech segment. Defaults to 10 ms.
+
+    Returns
+    -------
+    np.ndarray
+        A waveform containing the voiced portions of ``wav`` concatenated
+        together with fades applied. If ``speech_timestamps`` is empty, the
+        original ``wav`` is returned unchanged.
+    """
+    speech_timestamps = list(speech_timestamps)
+    if len(speech_timestamps) == 0:
+        return wav
+
+    fade_len = int(fade_duration * sr)
+    segs: List[np.ndarray] = []
+    for segment in speech_timestamps:
+        start = int(segment["start"] * sr)
+        end = int(segment["end"] * sr)
+        seg = wav[start:end].copy()
+        if seg.size == 0:
+            continue
+        fl = min(fade_len, seg.size // 2)
+        if fl > 0:
+            fade_in = np.linspace(0.0, 1.0, fl, endpoint=False)
+            fade_out = np.linspace(1.0, 0.0, fl, endpoint=True)
+            seg[:fl] *= fade_in
+            seg[-fl:] *= fade_out
+        segs.append(seg)
+
+    return np.concatenate(segs) if segs else wav

--- a/tests/test_trim_silence.py
+++ b/tests/test_trim_silence.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+# Ensure chatterbox package on path
+PKG_ROOT = Path(__file__).resolve().parents[1] / "chatterbox" / "src"
+if str(PKG_ROOT) not in sys.path:
+    sys.path.insert(0, str(PKG_ROOT))
+
+from chatterbox.utils import trim_silence
+
+
+def test_trim_silence_applies_fade_and_concatenates():
+    sr = 1000
+    wav = np.zeros(sr, dtype=np.float32)
+    wav[200:400] = 1.0
+    speech = [{"start": 0.2, "end": 0.4}]
+
+    trimmed = trim_silence(wav, speech, sr, fade_duration=0.02)
+
+    assert len(trimmed) == 200
+    assert trimmed[0] == 0.0
+    assert trimmed[20] == 1.0
+    assert trimmed[-1] == 0.0
+    assert trimmed[-21] == 1.0
+
+
+def test_trim_silence_no_timestamps_returns_original():
+    wav = np.arange(10, dtype=np.float32)
+    out = trim_silence(wav, [], 1)
+    assert np.array_equal(out, wav)


### PR DESCRIPTION
## Summary
- implement `trim_silence` utility with linear fade in/out for speech segments
- expose `trim_silence` from chatterbox package
- add unit tests covering fade behavior and no-speech case

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1e3a97e048332898c073e574a7f14