### PR TITLE
Add tests for punctuation normalization and sentence splitting with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest

--- a/tests/test_punc_norm.py
+++ b/tests/test_punc_norm.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+# Ensure chatterbox package on path
+PKG_ROOT = Path(__file__).resolve().parents[1] / "chatterbox" / "src"
+if str(PKG_ROOT) not in sys.path:
+    sys.path.insert(0, str(PKG_ROOT))
+
+from chatterbox.tts import punc_norm
+
+
+def test_punc_norm_empty_string():
+    assert punc_norm("") == "You need to add some text for me to talk."
+
+
+def test_punc_norm_handles_uncommon_punctuation():
+    text = "hello… \u201cworld\u201d \u2014 test"
+    expected = 'Hello,  "world" - test.'
+    assert punc_norm(text) == expected

--- a/tests/test_split_long_sentence.py
+++ b/tests/test_split_long_sentence.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import ast
+
+
+def _load_split_long_sentence():
+    file_path = Path(__file__).resolve().parents[1] / "Chatter.py"
+    source = file_path.read_text()
+    module_ast = ast.parse(source)
+    func_node = next(
+        node for node in module_ast.body
+        if isinstance(node, ast.FunctionDef) and node.name == "split_long_sentence"
+    )
+    module = ast.Module(body=[func_node], type_ignores=[])
+    code = compile(module, filename=str(file_path), mode="exec")
+    namespace = {}
+    exec(code, namespace)
+    return namespace["split_long_sentence"]
+
+
+split_long_sentence = _load_split_long_sentence()
+
+
+def test_split_long_sentence_empty_string():
+    assert split_long_sentence("", max_len=10) == [""]
+
+
+def test_split_long_sentence_no_separators():
+    sentence = "a" * 50
+    assert split_long_sentence(sentence, max_len=10) == ["a" * 10] * 5
+
+
+def test_split_long_sentence_with_spaces():
+    sentence = ("word " * 15).strip()
+    expected = [
+        "word word word word",
+        "word word word word",
+        "word word word word",
+        "word word word",
+    ]
+    assert split_long_sentence(sentence, max_len=20) == expected


### PR DESCRIPTION
## Summary
- add unit tests for `punc_norm` covering empty text and uncommon punctuation
- add unit tests for `split_long_sentence` covering empty and long sentences
- run tests in GitHub Actions workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1e758ad3483328700f4c83dd1f4a1