### PR TITLE
Pin dependency versions for reproducible installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,17 @@ pip install --force-reinstall -r requirements.txt
 # If needed, try requirements.base.with.versions.txt or requirements_frozen.txt
 ```
 
+### Updating dependencies
+
+`requirements.txt` pins exact versions for reproducible installs. When upgrading a
+package, update its version in `requirements.txt` and reinstall:
+
+```bash
+pip install --upgrade <package>
+pip install --force-reinstall -r requirements.txt
+```
+After adjusting versions, run the test suite to ensure everything works as expected.
+
 Run:
 ```bash
 # Use your repo's main file. For example:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,23 +1,23 @@
-gradio
-numpy
-faster-whisper
-openai-whisper
-ffmpeg-python
+gradio==5.32.0
+numpy==2.2.6
+nltk==3.9.1
+faster-whisper==1.1.1
+openai-whisper==20240930
+ffmpeg-python==0.2.0
 auto-editor==27.1.1
 resampy==0.4.3
 librosa==0.10.0
-s3tokenizer
-spaces
+s3tokenizer==0.1.7
+spaces==0.36.0
 transformers==4.46.3
 diffusers==0.29.0
 omegaconf==2.3.0
 resemble-perth==1.0.1
 silero-vad==5.1.2
 conformer==0.3.2
+soundfile==0.13.1
 pyrnnoise==0.3.8
-soundfile
-nltk
---extra-index-url=https://download.pytorch.org/whl/cu128
-torch==2.7.0
-torchaudio==2.7.0
+    --extra-index-url=https://download.pytorch.org/whl/cu128
+    torch==2.7.0
+    torchaudio==2.7.0
 


### PR DESCRIPTION
## Summary
- pin every package in `requirements.txt`
- document how to update pinned requirements in README

## Testing
- `pytest`
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy, Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ef934c6883329aed4a688c4cb7e6