### PR TITLE
Raise explicit error when target voice not set

### DIFF
--- a/chatterbox/src/chatterbox/vc.py
+++ b/chatterbox/src/chatterbox/vc.py
@@ -91,7 +91,10 @@ class ChatterboxVC:
         if target_voice_path:
             self.set_target_voice(target_voice_path, pitch_shift)
         else:
-            assert self.ref_dict is not None, "Please `prepare_conditionals` first or specify `target_voice_path`"
+            if self.ref_dict is None:
+                raise RuntimeError(
+                    "Please `set_target_voice` first or specify `target_voice_path`"
+                )
 
         with torch.inference_mode():
             audio_16, _ = librosa.load(audio, sr=S3_SR)

--- a/tests/test_vc_target_voice_required.py
+++ b/tests/test_vc_target_voice_required.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+import pytest
+
+# Ensure chatterbox package is on the path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "chatterbox" / "src"))
+
+from chatterbox.vc import ChatterboxVC
+
+
+class DummyS3Gen:
+    def tokenizer(self, audio):
+        return torch.zeros((1, 1)), None
+
+    def inference(self, speech_tokens, ref_dict):
+        return torch.tensor([[0.1, 0.2, 0.3]]), None
+
+
+def fake_load(path, sr):
+    return np.zeros(sr), sr
+
+
+def test_generate_requires_target_voice(monkeypatch):
+    monkeypatch.setattr("chatterbox.vc.librosa.load", fake_load)
+    vc = ChatterboxVC(s3gen=DummyS3Gen(), device="cpu", ref_dict=None)
+    with pytest.raises(RuntimeError):
+        vc.generate("dummy.wav")


### PR DESCRIPTION
## Summary
- Replace assert in `ChatterboxVC.generate` with explicit `RuntimeError` when no target voice is set
- Add unit test to ensure `generate` fails without `set_target_voice`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1f37246e48332810f4c75493e6bc1